### PR TITLE
[WIP] Add alert state handling

### DIFF
--- a/x-pack/plugins/endpoint/server/routes/alerts/common.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/common.ts
@@ -3,3 +3,4 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
+const SAVED_OBJECT_TYPE_ALERT_STATE: string = 'endpoint-alert-state';

--- a/x-pack/plugins/endpoint/server/routes/alerts/details/handlers.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/details/handlers.ts
@@ -7,7 +7,8 @@ import { KibanaRequest, RequestHandler } from 'kibana/server';
 import { SearchResponse } from 'elasticsearch';
 import { AlertData, AlertDataWrapper } from '../../../../common/types';
 import { EndpointAppContext } from '../../../types';
-import { AlertDetailsRequestParams } from './types';
+import { SAVED_OBJECT_TYPE_ALERT_STATE } from '../common';
+import { AlertDetailsRequestParams, AlertDetailsUpdateParams } from './types';
 
 export const alertDetailsHandlerWrapper = function(
   endpointAppContext: EndpointAppContext
@@ -38,4 +39,38 @@ export const alertDetailsHandlerWrapper = function(
   };
 
   return alertDetailsHandler;
+};
+
+export const alertDetailsUpdateHandlerWrapper = function(
+  endpointAppContext: EndpointAppContext
+): RequestHandler<AlertDetailsRequestParams, unknown, AlertDetailsUpdateParams> {
+  const alertDetailsUpdateHandler: RequestHandler<
+    AlertDetailsRequestParams,
+    unknown,
+    AlertDetailsUpdateParams
+  > = async (
+    ctx,
+    req: KibanaRequest<AlertDetailsRequestParams, unknown, AlertDetailsUpdateParams>,
+    res
+  ) => {
+    try {
+      const savedObjectsClient = ctx.core.savedObjects.client;
+      // console.log(savedObjectsClient);
+      const alertId = req.params.id;
+      const savedObjectsResponse = await savedObjectsClient.update(
+        SAVED_OBJECT_TYPE_ALERT_STATE,
+        alertId,
+        {
+          active: req.body.active,
+        }
+      );
+      // console.log(savedObjectsResponse);
+      return res.noContent();
+    } catch (err) {
+      // console.log(err);
+      return res.internalError({ body: err });
+    }
+  };
+
+  return alertDetailsUpdateHandler;
 };

--- a/x-pack/plugins/endpoint/server/routes/alerts/details/schemas.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/details/schemas.ts
@@ -8,3 +8,9 @@ import { schema } from '@kbn/config-schema';
 export const alertDetailsReqSchema = schema.object({
   id: schema.string(),
 });
+
+export const alertDetailsUpdateSchema = schema.object({
+  state: schema.object({
+    active: schema.maybe(schema.boolean()),
+  }),
+});

--- a/x-pack/plugins/endpoint/server/routes/alerts/details/types.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/details/types.ts
@@ -10,3 +10,10 @@
 export interface AlertDetailsRequestParams {
   id: string;
 }
+
+/**
+ * Request params for updating alert details.
+ */
+export interface AlertDetailsUpdateParams {
+  active: boolean;
+}

--- a/x-pack/plugins/endpoint/server/routes/alerts/index.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/index.ts
@@ -6,10 +6,17 @@
 import { IRouter } from 'kibana/server';
 import { EndpointAppContext } from '../../types';
 import { EndpointAppConstants } from '../../../common/types';
-import { alertListHandlerWrapper } from './list/handlers';
-import { alertListReqSchema } from './list/schemas';
+import { alertListHandlerWrapper, alertListUpdateHandlerWrapper } from './list/handlers';
+import {
+  alertListReqSchema,
+  alertListUpdateQuerySchema,
+  alertListUpateBodySchema,
+  alertListUpdateBodySchema,
+} from './list/schemas';
 import { alertDetailsReqSchema } from './details/schemas';
+import { alertDetailsUpdateSchema } from './details/schemas';
 import { alertDetailsHandlerWrapper } from './details/handlers';
+import { alertDetailsUpdateHandlerWrapper } from './details/handlers';
 
 const BASE_ALERTS_ROUTE = `${EndpointAppConstants.BASE_API_URL}/alerts`;
 
@@ -36,6 +43,18 @@ export function registerAlertRoutes(router: IRouter, endpointAppContext: Endpoin
     alertDetailsHandlerWrapper(endpointAppContext)
   );
 
+  router.patch(
+    {
+      path: `${BASE_ALERTS_ROUTE}/{id}`,
+      validate: {
+        params: alertDetailsReqSchema,
+        body: alertDetailsUpdateSchema,
+      },
+      options: { authRequired: true },
+    },
+    alertDetailsUpdateHandlerWrapper(endpointAppContext)
+  );
+
   router.post(
     {
       path: BASE_ALERTS_ROUTE,
@@ -45,5 +64,17 @@ export function registerAlertRoutes(router: IRouter, endpointAppContext: Endpoin
       options: { authRequired: true },
     },
     alertListHandlerWrapper(endpointAppContext)
+  );
+
+  router.patch(
+    {
+      path: BASE_ALERTS_ROUTE,
+      validate: {
+        query: alertListUpdateQuerySchema,
+        body: alertListUpdateBodySchema,
+      },
+      options: { authRequired: true },
+    },
+    alertListUpdateHandlerWrapper(endpointAppContext)
   );
 }

--- a/x-pack/plugins/endpoint/server/routes/alerts/list/handlers.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/list/handlers.ts
@@ -7,8 +7,9 @@ import { KibanaRequest, RequestHandler } from 'kibana/server';
 import { SearchResponse } from 'elasticsearch';
 import { AlertData } from '../../../../common/types';
 import { EndpointAppContext } from '../../../types';
+import { SAVED_OBJECT_TYPE_ALERT_STATE } from '../common';
 import { getRequestData, buildAlertListESQuery, mapToAlertResultList } from './lib';
-import { AlertListRequestParams } from './types';
+import { AlertListRequestParams, AlertListUpdateParams, AlertListUpdateBody } from './types';
 
 export const alertListHandlerWrapper = function(
   endpointAppContext: EndpointAppContext
@@ -35,6 +36,51 @@ export const alertListHandlerWrapper = function(
 
       return res.ok({ body: mapToAlertResultList(endpointAppContext, reqData, response) });
     } catch (err) {
+      return res.internalError({ body: err });
+    }
+  };
+
+  return alertListHandler;
+};
+
+export const alertListUpdateHandlerWrapper = function(
+  endpointAppContext: EndpointAppContext
+): RequestHandler<unknown, unknown, AlertListUpdateParams> {
+  const alertListHandler: RequestHandler<unknown, unknown, AlertListUpdateParams> = async (
+    ctx,
+    req: KibanaRequest<unknown, unknown, AlertListRequestParams>,
+    res
+  ) => {
+    try {
+      /**
+       * In progress:
+       *
+       * 1. Look up alerts
+       *
+       * 2. Call SavedObjectsClient.bulkGet() to get state
+       * https://github.com/elastic/kibana/blob/aa695ec6370e83e6cd595004c7d08e266fad0930/docs/development/core/server/kibana-plugin-server.savedobjectsclient.bulkget.md
+       *
+       * 3. Join the data by alert ID and return
+       */
+
+      // 1. Look up alerts
+      // TODO
+
+      // 2. Get saved objects
+      const savedObjectsClient = ctx.core.savedObjects.client;
+      // console.log(savedObjectsClient);
+      const alertIds = req.body;
+      const savedObjectsResponse = await savedObjectsClient.update(
+        SAVED_OBJECT_TYPE_ALERT_STATE,
+        alertId,
+        {
+          active: req.body.active,
+        }
+      );
+      // console.log(savedObjectsResponse);
+      return res.noContent();
+    } catch (err) {
+      // console.log(err);
       return res.internalError({ body: err });
     }
   };

--- a/x-pack/plugins/endpoint/server/routes/alerts/list/schemas.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/list/schemas.ts
@@ -47,3 +47,15 @@ export const alertListReqSchema = schema.object(
     },
   }
 );
+
+export const alertListUpdateQuerySchema = schema.object({
+  alert_ids: schema.arrayOf(schema.string(), {
+    minSize: 1,
+  }),
+});
+
+export const alertListUpdateBodySchema = schema.object({
+  state: schema.object({
+    active: schema.maybe(schema.boolean()),
+  }),
+});

--- a/x-pack/plugins/endpoint/server/routes/alerts/list/types.ts
+++ b/x-pack/plugins/endpoint/server/routes/alerts/list/types.ts
@@ -70,3 +70,10 @@ export interface AlertListRequest {
   from?: number;
   body: AlertListRequestBody;
 }
+
+/**
+ * Request body for updating alerts.
+ */
+export interface AlertListUpdateBody {
+  alert_ids: string[];
+}


### PR DESCRIPTION
## TODO
- [ ] Update Alert List GET and Alert Details GET APIs to return `state: {...}` for each alert
- [ ] Start implementing retrieval of latest host data (from `events` index? saved objects?)
- [ ] Finish implementation of saved objects queries
- [ ] Implement filter/sort/paginate for the merged data sets

## Summary
State for alerts will be stored using Saved Objects. We'll create a new Saved Object type called `endpoint-alert-state` which will look like the following:

**Saved Object Attributes for a Single Alert (e.g.)**
```
{
  // The alert ID
  id: "xDUYMHABAJk0XnHd8rrd",

  // The time the event was generated (duplicated for filtering purposes)
  @timestamp: 1542789473000,

  // The current state of the alert
  state: {
    // alert is open, can be closed be setting to false
    active: true
  }
}
```

## API

**Updates**
Updates can be performed on either a single alert, or in bulk on a group of alerts at once. The PATCH verb is used so that individual attributes can be changed without affecting other attributes. This avoids races that might occur when overwriting the alert state in whole. That said, for now, there's really only 1 attribute that can change... the open/closed state.

```
// Closes the alert
PATCH api/endpoint/alerts/xDUYMHABAJk0XnHd8rrd
{
  state: {
    active: false
  }
}

// Closes several alerts in bulk
PATCH api/endpoints/alerts
{
  alert_ids: ["uzUYMHABAJk0XnHd8roO", "XDUYMHABAJk0XnHd6Lq7", "oDUYMHABAJk0XnHd77qM"],
  state: {
    active: false
  }
}

// 400 BAD REQUEST -- not allowed to update host state (that only happens internally)
PATCH api/endpoints/alerts
{
  alert_ids: ["uzUYMHABAJk0XnHd8roO", "XDUYMHABAJk0XnHd6Lq7", "oDUYMHABAJk0XnHd77qM"],
  state: {
    host: {
      ip: '192.168.1.73'
    }
  }
}
```

**See https://github.com/madirey/kibana/pull/1 for retrieval of `state` data through the Alert List and Alert Details APIs.**

**Querying/Joining**
The main problem we have is paginating and filtering data that is coming from heterogenous data sources. If `<Clause A> AND <Clause B> (AND <Clause C>)` is given as a search query, and A, B, or C are in different indices (or at different sources), then you could end up in a situation where you're making an unbounded number of queries to retrieve the data.

To avoid this problem, it's been suggested that we HIGHLY encourage a limited date range to be appended to the query, so that we can avoid scaling problems when users select a performance-prohibitive set of filters.

The other alternative that I can think of would be to duplicate the immutable alert data from the event index into the saved objects, but that will be space-prohibitive. And we'd still have to join the `host` state at runtime.

In order to join data from the events index and the alert-state saved objects index, we'll have to do the following in the **alert list GET handler**:

1. When a set of filters is provided, determine if `state.active` is being filtered on. If so, extract those filters into `alert_state_filters`.

2. Determine if `state.host` is being filtered on. If so, extract those filters into `alert_state_host_filters`.

3. If there are other filters remaining, add those to `alert_data_filters`.

4. Additionally, you have to take note of the `sort` parameter and direction that is provided.

5. If the sorts and the filters are all within the primary alerts data source, the solution is easier. You just get the alerts, then join the data from the other 2 sources and return it. Total of 3 API calls for 3 data sources.

6. If we have filtering and/or sorting across multiple data sources, however, the solution is more complicated. This is where we could end up with an unbounded number of queries if a sufficiently small date range isn't provided. We'll have to make M calls to ES to scroll through alert matches, N calls to the Saved Objects store to scroll through alert state, and P calls to retrieve the host state ... each time checking the merged sets of data against the set of filters to see if they match. Once we've accumulated `page_size` results OR there are no more matches from either data store, we can stop. But if we never reach `page_size` and we're still getting results, then we could keep scrolling forever (or until the request times out, more likely)... **Smart caching** could potentially be helpful, in some cases.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

